### PR TITLE
Make sure response is present before extracting_error from `#response`

### DIFF
--- a/lib/packlink_lite/client.rb
+++ b/lib/packlink_lite/client.rb
@@ -29,7 +29,12 @@ module PacklinkLite
     def with_error_handling
       yield
     rescue Faraday::ClientError => e
-      message = extract_error_message(e.response[:body]) || e.message
+      message = if e.response.present?
+                  extract_error_message(e.response[:body])
+                else
+                  e.message
+                end
+
       raise(Error, message)
     end
 


### PR DESCRIPTION
Handle Net::ReadTimeout errors which does not contain response from the API.

Jira task: https://jira.catawiki.net/browse/OM-2150

Example of the error happening inside `packlink_lite` gem.
<img width="1215" alt="screen shot 2018-05-17 at 10 53 11" src="https://user-images.githubusercontent.com/1288959/40176332-5602f6f0-59db-11e8-8818-0a9e2809ce1a.png">
